### PR TITLE
Adapting code to accept external autoproj ros packages

### DIFF
--- a/manifest
+++ b/manifest
@@ -1,9 +1,12 @@
 package_sets:
-  # - github: Brazilian-Institute-of-Robotics/bir.ros-package_set
-  #   private: true
+  - github: ivan1993br/autoproj.configuration-package_set
+    private: true
+  - github: ivan1993br/ros.official-package_set
+    private: true
   - github: JotellyBarros/concept_demo_package_set.git
     private: true
 
 layout:
   #- desktop_full
   - video_stream_opencv
+  - video_stream_opencv_custom


### PR DESCRIPTION
This adaption is to separate ros package sets, configuration package sets and personal use package sets

Here I adapt to use `video_stream_opencv_custom`, because `video_stream_opencv` is already a system package, however change a system package is not a good idea, maybe you can think in another solution, using the package itself